### PR TITLE
Add question_queue to INSTALLED_APPS

### DIFF
--- a/cclc_queue/settings.py
+++ b/cclc_queue/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "question_queue",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
In PR https://github.com/MTUHIDE/CCLC-Queue-Django/pull/3 the new app `question_queue` was never added to `INSTALLED_APPS`. This simply addresses that. 